### PR TITLE
Add data-* attribute support

### DIFF
--- a/lib/attr.js
+++ b/lib/attr.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  getAttr: function getAttr(attr, attrs) {
+    if (!attrs) {
+      return null;
+    }
+
+    if (attr in attrs) {
+      return attr;
+    }
+
+    if ('data-' + attr in attrs) {
+      return 'data-' + attr;
+    }
+
+    return null;
+  }
+};

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,7 +1,10 @@
+'use strict';
+
 var _ = require('lodash');
 var Hogan = require('hogan.js');
 var hoganCache = {};
 var async = require('async');
+var getAttr = require('./attr').getAttr;
 
 function render(text, data) {
     if(!hoganCache[text]) {
@@ -54,8 +57,15 @@ function pushFragment(tagname, attribs, state, deferred, handler) {
 
 function processDeferredStack(config, state, next) {
     async.mapSeries(state.getDeferredStack(), function(deferred, cb) {
-        if(deferred.fragment.attribs['cx-url']) { deferred.fragment.attribs['cx-url'] = render(deferred.fragment.attribs['cx-url'], config.variables); }
-        deferred.handler(deferred.fragment, function(err, response) {
+        var fragment = deferred.fragment;
+        var attrs = fragment.attribs;
+        var urlAttr = getAttr(config.prefix + 'url', attrs);
+
+        if (urlAttr) {
+          attrs[urlAttr] = render(attrs[urlAttr], config.variables);
+        }
+
+        deferred.handler(fragment, function(err, response) {
             deferred.callback(err, response);
             cb();
         });

--- a/lib/plugins/direct.js
+++ b/lib/plugins/direct.js
@@ -1,9 +1,14 @@
+'use strict';
+
 var Core = require('../core');
+var getAttr = require('../attr').getAttr;
 
 function match(tagname, attribs, config) {
-    if(attribs && attribs[config.prefix + 'direct']) {
-      return Core.render(attribs['cx-direct'], config.variables);
-    }
+  var directAttr = getAttr(config.prefix + 'direct', attribs)
+
+  if(directAttr) {
+    return Core.render(attribs[directAttr], config.variables);
+  }
 }
 
 module.exports = {

--- a/lib/plugins/test.js
+++ b/lib/plugins/test.js
@@ -1,11 +1,16 @@
+'use strict';
+
 var Core = require('../core');
+var getAttr = require('../attr').getAttr;
 
 function match(tagname, attribs, config, state) {
-    if(attribs && attribs[config.prefix + 'test']) {
-      state.setOutput(Core.createTag(tagname, attribs));
-      state.setOutput(Core.render(attribs['cx-test'], config.variables));
-      return true;
-    }
+  var testAttr = getAttr(config.prefix + 'test', attribs);
+
+  if (testAttr) {
+    state.setOutput(Core.createTag(tagname, attribs));
+    state.setOutput(Core.render(attribs[testAttr], config.variables));
+    return true;
+  }
 }
 
 module.exports = {

--- a/lib/plugins/url.js
+++ b/lib/plugins/url.js
@@ -1,5 +1,8 @@
+'use strict';
+
 var Core = require('../core');
 var _ = require('lodash');
+var getAttr = require('../attr').getAttr;
 
 module.exports = function(handler) {
 
@@ -11,12 +14,17 @@ module.exports = function(handler) {
   */
   function parseAttribs(attribs, config) {
     attribs = _.clone(attribs);
+
     parsedAttribs.forEach(function(attrib) {
-        if(attribs[config.prefix + attrib]) {
-          attribs[config.prefix + attrib + rawSuffix] = attribs[config.prefix + attrib];
-          attribs[config.prefix + attrib] = Core.render(attribs[config.prefix + attrib], config.variables);
+        var real = getAttr(config.prefix + attrib, attribs);
+        var raw = real + rawSuffix;
+
+        if (real) {
+          attribs[raw] = attribs[real];
+          attribs[real] = Core.render(attribs[real], config.variables);
         }
     });
+
     return attribs;
   }
 
@@ -25,9 +33,12 @@ module.exports = function(handler) {
     responds to cx-url="{{server:name}}/path" declarations
   */
   function matchUrl(tagname, attribs, config, state) {
-    if(attribs && attribs[config.prefix + 'url']) {
+    var urlAttr = getAttr(config.prefix + 'url', attribs);
+    var replaceOuterAttr = getAttr(config.prefix + 'replace-outer', attribs);
+
+    if(urlAttr) {
       attribs = parseAttribs(attribs, config);
-      if(attribs[config.prefix + 'replace-outer']) {
+      if(attribs[replaceOuterAttr]) {
           state.setSkipClosingTag(true);
       } else {
           state.setOutput(Core.createTag(tagname, attribs));
@@ -47,9 +58,19 @@ module.exports = function(handler) {
     by the first round of cx-url requests
   */
   function matchBundles(tagname, attribs, config, state) {
-    if(attribs && attribs[config.prefix + 'bundles']) {
+    var bundlesAttr = getAttr(config.prefix + 'bundles', attribs);
+    var bundlesRawAttr = bundlesAttr + rawSuffix;
+    var replaceOuterAttr = getAttr(config.prefix + 'replace-outer', attribs);
+    var directAttr = config.prefix + 'direct';
+    var urlAttr = config.prefix + 'url';
 
-       var bundleNames = Core.render(attribs[config.prefix + 'bundles'], config.variables).split(','), baseUrl;
+    if(bundlesAttr) {
+        if (bundlesAttr.substr(0, 5) === 'data-') {
+          urlAttr = 'data-' + urlAttr;
+          directAttr = 'data-' + directAttr;
+        }
+
+       var bundleNames = Core.render(attribs[bundlesAttr], config.variables).split(','), baseUrl;
        var bundles = _.map(bundleNames, function(bundle) {
           if(bundle.indexOf('/') >= 0) {
             var splitBundle = bundle.split('/');
@@ -74,23 +95,23 @@ module.exports = function(handler) {
                   bundleUrl = baseUrl + bundle.service + '/' + bundleVersion + '/html/' + bundle.name + '.html',
                   directAssetUrl = baseUrl + bundle.service + '/' + bundleVersion + '/' + bundleType + '/' + bundle.name;
 
-              bundleAttribs[config.prefix + 'bundles' + rawSuffix] = bundleAttribs[config.prefix + 'bundles'];
-              delete bundleAttribs[config.prefix + 'bundles'];
-              if(bundleAttribs[config.prefix + 'replace-outer']) {
+              bundleAttribs[bundlesRawAttr] = bundleAttribs[bundlesAttr];
+              delete bundleAttribs[bundlesAttr];
+              if(bundleAttribs[replaceOuterAttr]) {
                   state.setSkipClosingTag(true);
               } else {
                   state.setOutput(Core.createTag(tagname, attribs));
               }
               if(config.minified) {
                 // Set the content directly vs adding a fragment
-                bundleAttribs[config.prefix + 'direct'] = createTag(bundleType, directAssetUrl);
+                bundleAttribs[directAttr] = createTag(bundleType, directAssetUrl);
                 Core.pushFragment(tagname, bundleAttribs, state, bundle, function(fragment, next) {
                   var testHandler = require('./direct');
                   next(null, testHandler.match(fragment.tagname, fragment.attribs, config, state));
                 });
               } else {
-                bundleAttribs[config.prefix + 'url'] = bundleUrl;
-                Core.pushFragment(tagname, bundleAttribs, state, bundle, handler);
+                bundleAttribs[urlAttr] = bundleUrl;
+                Core.pushFragment(tagname, bundleAttribs, state, true, handler);
               }
             }
           });


### PR DESCRIPTION
This PR adds support for the `data-` prefix for attributes.

This prefix is applied in addition to the prefix specified in parxer.