### PR TITLE
Simple inline bundle approach

### DIFF
--- a/lib/plugins/bundle.js
+++ b/lib/plugins/bundle.js
@@ -31,6 +31,7 @@ module.exports = function(handler) {
     var bundlesAttrDone = attr.getAttr(config.prefix + 'bundles-done', attribs);
     var bundlesRawAttr = bundlesAttr + config.rawSuffix;
     var replaceOuterAttr = attr.getAttr(config.prefix + 'replace-outer', attribs);
+    var inlineAttr = attr.getAttr(config.prefix + 'inline', attribs);
     var directAttr = config.prefix + 'direct';
     var urlAttr = config.prefix + 'url';
 
@@ -100,6 +101,11 @@ module.exports = function(handler) {
       bundleAttribs[bundlesRawAttr] = bundleAttribs[bundlesAttr];
       delete bundleAttribs[bundlesAttr];
 
+      if(inlineAttr && replaceOuterAttr) {
+        // Can't have both inline and replace outer, inline takes precedence
+        replaceOuterAttr = false;
+      }
+
       if(replaceOuterAttr || Core.isCxCustomTag(tagname)) {
           state.setSkipClosingTag(tagname);
       } else {
@@ -110,14 +116,28 @@ module.exports = function(handler) {
       state.setStatistic('bundles', bundleKey, bundle);
 
       if(config.minified) {
-        // Set the content directly vs adding a fragment
-        bundleAttribs[directAttr] = createTag(bundleType, directAssetUrl);
 
-        // Direct plugin will take care of rendering the correct element to add once we come back from the deferred stack
-        Core.pushFragment(tagname, bundleAttribs, state, true, function(fragment, next) {
-          var testHandler = require('./direct');
-          next(null, testHandler.match(fragment.tagname, fragment.attribs, config, state));
-        });
+        if(inlineAttr) {
+
+          // Pull the actual CSS in as the body element
+          bundleAttribs[urlAttr] = directAssetUrl;
+          Core.pushFragment(tagname, bundleAttribs, state, true, handler);
+
+        } else {
+
+          // Set the content directly vs adding a fragment
+          bundleAttribs[directAttr] = createTag(bundleType, directAssetUrl);
+
+          // Direct plugin will take care of rendering the correct element to add once we come back from the deferred stack
+          Core.pushFragment(tagname, bundleAttribs, state, true, function(fragment, next) {
+
+            // Core.render(attribs[directAttr], config.variables);
+            var testHandler = require('./direct');
+            next(null, testHandler.match(fragment.tagname, fragment.attribs, config, state));
+
+          });
+        }
+
       } else {
         bundleAttribs[urlAttr] = bundleUrl;
         Core.pushFragment(tagname, bundleAttribs, state, true, handler);

--- a/tests/bundle.test.js
+++ b/tests/bundle.test.js
@@ -73,6 +73,28 @@ describe("Bundle parsing", function() {
       });
   });
 
+  it('should parse bundle attributes and inline css urls if in minfied mode with cx-inline', function(done) {
+      var input = "<html><style id='bundle' cx-inline cx-bundles='service-name/top.css'></style></html>";
+      parxer({
+        plugins: [
+          require('../Plugins').Bundle(function(fragment, next) { next(null, fragment.attribs['cx-url']); })
+        ],
+        cdn: {
+          url: 'http://base.url.com/'
+        },
+        minified: true,
+        environment: 'test',
+        variables: {
+          'static:service-name|top':'50',
+          'server:name':'http://www.google.com'
+        }
+      }, input, function(err, fragmentCount, data) {
+        var $ = cheerio.load(data);
+        expect($('#bundle').text()).to.be('http://base.url.com/service-name/50/css/top.css');
+        done();
+      });
+  });
+
   it('should replace outer when specified with bundle', function(done) {
       var input = "<html><div id='bundle'><div cx-replace-outer='true' cx-bundles='service-name/top.js'><script id='default'>This is some default script</script></div></div></html>";
       parxer({


### PR DESCRIPTION
Lets say we use app-home as example, if we want to inline its css:

https://github.com/tes/app-home/blob/master/src/app/views/layouts/main.hbs#L49

Change:

```html
  <link cx-bundles="app-home/main.css" cx-replace-outer="true" cx-ignore-error="true" />
```

To

```html
  <style cx-bundles="app-home/main.css" cx-inline></style>
```

Related to:  https://github.com/tes/frontend-team/issues/23#issuecomment-260709601