### PR TITLE
Have bundle use only the service name, not the bundle name to resolve…

### DIFF
--- a/lib/plugins/bundle.js
+++ b/lib/plugins/bundle.js
@@ -72,7 +72,7 @@ module.exports = function(handler) {
       var bundleType = bnamesplit.pop();
 
       // Create an image key that will be used to determine which version will be used for the bundle url
-      var bundleKey = bundle.service + '|' + bnamesplit.join('.');
+      var bundleKey = bundle.service;
 
       bundleKey = bundleKey.replace(/\./g, '::');
 

--- a/lib/plugins/url.js
+++ b/lib/plugins/url.js
@@ -20,6 +20,11 @@ module.exports = function(handler) {
       return false;
     }
 
+    if (attribs['cx-url'] && attribs['cx-url'].indexOf('rz') >= 0) {
+      console.log(attribs);
+    }
+
+
     attribs = attr.parseAttribs(parsedAttribs, attribs, config);
     if(replaceOuterAttr || Core.isCxCustomTag(tagname)) {
         state.setSkipClosingTag(tagname);
@@ -29,6 +34,7 @@ module.exports = function(handler) {
     }
 
     Core.pushFragment(tagname, attribs, state, null, handler);
+
 
     state.setStatistic('fragments', attribs['cx-url'], {attribs: attribs});
 

--- a/tests/bundle.test.js
+++ b/tests/bundle.test.js
@@ -19,7 +19,7 @@ describe("Bundle parsing", function() {
         },
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -41,7 +41,7 @@ describe("Bundle parsing", function() {
         minified: true,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -64,7 +64,7 @@ describe("Bundle parsing", function() {
         minified: true,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -86,7 +86,7 @@ describe("Bundle parsing", function() {
         minified: true,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -109,7 +109,7 @@ describe("Bundle parsing", function() {
         minified: true,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         },
         commonState: commonState
@@ -134,7 +134,7 @@ describe("Bundle parsing", function() {
         minified: true,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -157,7 +157,7 @@ describe("Bundle parsing", function() {
         minified: true,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -180,7 +180,7 @@ describe("Bundle parsing", function() {
         minified: false,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -202,7 +202,7 @@ describe("Bundle parsing", function() {
         minified: false,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -224,7 +224,7 @@ describe("Bundle parsing", function() {
         minified: false,
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -286,7 +286,7 @@ describe("Bundle parsing", function() {
         },
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -307,11 +307,11 @@ describe("Bundle parsing", function() {
         },
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
-        expect(err.statistics.bundles['service-name|top'].service).to.be('service-name');
+        expect(err.statistics.bundles['service-name'].service).to.be('service-name');
         done();
       });
   });
@@ -327,7 +327,7 @@ describe("Bundle parsing", function() {
         },
         environment: 'test',
         variables: {
-          'static:service-name|top.2.0':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -353,8 +353,8 @@ describe("Bundle parsing", function() {
         },
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
-          'static:service-other-name|bottom':'51',
+          'static:service-name':'50',
+          'static:service-other-name':'51',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -375,7 +375,7 @@ describe("Bundle parsing", function() {
         },
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {
@@ -398,7 +398,7 @@ describe("Bundle parsing", function() {
         },
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {

--- a/tests/if.test.js
+++ b/tests/if.test.js
@@ -101,7 +101,7 @@ describe("If logic plugin", function() {
         },
         environment: 'test',
         variables: {
-          'static:service-name|top':'50',
+          'static:service-name':'50',
           'server:name':'http://www.google.com'
         }
       }, input, function(err, fragmentCount, data) {


### PR DESCRIPTION
… version

@jonnywyatt @sithmel 

This removes PC looking for them, will submit second change to bundle-version middleware that stops sending them (need to deploy PC change first of course!).

Backwards compatible as the current middleware always sends the bare `service|version` that this users.