### PR TITLE
Allow data-cx-content, use commonState for content state

### DIFF
--- a/lib/plugins/content-item.js
+++ b/lib/plugins/content-item.js
@@ -5,12 +5,14 @@ var attr = require('../attr');
 
 function match(tagname, attribs, config, state) {
   var contentAttr = attr.getAttr(config.prefix + 'content-item', attribs)
+  var contentContextAttr = attr.getAttr(config.prefix + 'content-context', attribs) || config.prefix + 'content-context';
   var contentDoneAttr = attr.getAttr(config.prefix + 'content-item-done', attribs)
   var replaceOuterAttr = attr.getAttr(config.prefix + 'replace-outer', attribs);
 
   function render(fragment, next) {
-    var item = fragment.attribs[config.prefix + 'content-item'];
-    var contentContext = fragment.attribs[config.prefix + 'content-context'];
+    var item = fragment.attribs[contentAttr];
+    var contentContext = fragment.attribs[contentContextAttr];
+
     var contentContextIsInPage = state.getContent(contentContext);
 
     if (!contentContextIsInPage) {
@@ -27,13 +29,14 @@ function match(tagname, attribs, config, state) {
 
   if(contentAttr && !contentDoneAttr) {
       var contentContext = contentAttr && attribs[contentAttr].split(':')[1];
+
       if(replaceOuterAttr || Core.isCxCustomTag(tagname)) {
         state.setSkipClosingTag(tagname);
       } else {
         attribs[config.prefix + 'content-item-done'] = 'true';
         state.setOutput(Core.createTag(tagname, attribs));
       }
-      attribs[config.prefix + 'content-context'] = contentContext;
+      attribs[contentContextAttr] = contentContext;
       Core.pushFragment(tagname, attribs, state, true, render);
       return true;
 

--- a/lib/plugins/content.js
+++ b/lib/plugins/content.js
@@ -25,7 +25,7 @@ module.exports = function(handler) {
     state.setOutput(Core.createTag(tagname, attribs));
 
     Core.pushFragment(tagname, attribs, state, null, handler, function() {
-      var contentTag = attribs[config.prefix + 'content'];
+      var contentTag = attribs[contentAttr];
       state.setContent(contentTag);
     });
 

--- a/lib/plugins/if.js
+++ b/lib/plugins/if.js
@@ -5,6 +5,7 @@ var attr = require('../attr');
 
 function match(tagname, attribs, config, state) {
   var ifAttr = attr.getAttr(config.prefix + 'if', attribs);
+  var ifValueAttr = attr.getAttr(config.prefix + 'if-value', attribs);
   var ifAttrCompleted = attr.getAttr(config.prefix + 'if-done', attribs);
   var replaceOuterAttr = attr.getAttr(config.prefix + 'replace-outer', attribs);
 
@@ -12,7 +13,7 @@ function match(tagname, attribs, config, state) {
     return false;
   }
 
-  var logicTest = Core.render(attribs['cx-if'], config.variables) === attribs['cx-if-value'];
+  var logicTest = Core.render(attribs[ifAttr], config.variables) === attribs[ifValueAttr];
 
   if (!logicTest) {
     state.setBlock('if-false', tagname);

--- a/lib/state.js
+++ b/lib/state.js
@@ -14,13 +14,13 @@ function create(config) {
       blocks: {},
       blockCloseTags: {},
       tagCount: 0,
-      content: {},
       statistics: {},
       commonState: config.commonState || {}, // optional: shared between different requests
   };
 
   state.commonState.additionalHeaders = state.commonState.additionalHeaders || {};
   state.commonState.alreadyImported = state.commonState.alreadyImported || {};
+  state.commonState.content = state.commonState.content || {};
 
   function closeTag(tagname) {
     return tagname + ':' + state.tagCount;
@@ -126,10 +126,10 @@ function create(config) {
         state.deferredStack.push(item);
       },
       setContent: function(context) {
-        state.content[context] = true;
+        state.commonState.content[context] = true;
       },
       getContent: function(context) {
-        return !!state.content[context];
+        return !!state.commonState.content[context];
       },
       _raw: function() {
         return _.clone(state);


### PR DESCRIPTION
We ran into an issue trying to use data-cx-content tags -`data` gets prepended to the attr here https://github.com/tes/parxer/blob/a6e52a021f78ae81a56e81b84c081781799d72c1/lib/attr.js#L13-L15 , but this attr was not being used in a few circumstances.

While looking into this error, @geophree and I found an issue where `state.setContent` in `content.js` (https://github.com/tes/parxer/compare/allow-data-cx-content?expand=1#diff-0a1106776fd9b19cf02b5ea48c4823d1R29) was using a different state from the `state.getContent` call in `content-item.js` (https://github.com/tes/parxer/compare/allow-data-cx-content?expand=1#diff-9b0d4caa1bf9709c0687f0c0eab9f6e0R16), so we changed content to rely on `state.commonState.content`.

With these changes in place, we were able to render a `data-cx-content-item` locally